### PR TITLE
Feat(WatchLater)

### DIFF
--- a/lib/smovie/accounts/user.ex
+++ b/lib/smovie/accounts/user.ex
@@ -13,6 +13,7 @@ defmodule Smovie.Accounts.User do
     field :confirmed_at, :utc_datetime
 
     has_many :watched_list, Smovie.Movies.WatchedList
+    has_many :watche_later, Smovie.Movies.WatchedLater
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/smovie/movies.ex
+++ b/lib/smovie/movies.ex
@@ -105,4 +105,104 @@ defmodule Smovie.Movies do
   def change_watched_list(%WatchedList{} = watched_list, attrs \\ %{}) do
     WatchedList.changeset(watched_list, attrs)
   end
+
+  alias Smovie.Movies.WatchLater
+
+  @doc """
+  Returns the list of watchelater.
+
+  ## Examples
+
+      iex> list_watchelater()
+      [%WatchLater{}, ...]
+
+  """
+  def list_watchelater do
+    Repo.all(WatchLater)
+  end
+
+  def list_watch_later_for_user(user_id) do
+    Repo.all(from wl in WatchLater, where: wl.user_id == ^user_id)
+  end
+
+  @doc """
+  Gets a single watch_later.
+
+  Raises `Ecto.NoResultsError` if the Watch later does not exist.
+
+  ## Examples
+
+      iex> get_watch_later!(123)
+      %WatchLater{}
+
+      iex> get_watch_later!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_watch_later!(id), do: Repo.get!(WatchLater, id)
+
+  @doc """
+  Creates a watch_later.
+
+  ## Examples
+
+      iex> create_watch_later(%{field: value})
+      {:ok, %WatchLater{}}
+
+      iex> create_watch_later(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_watch_later(attrs \\ %{}) do
+    %WatchLater{}
+    |> WatchLater.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a watch_later.
+
+  ## Examples
+
+      iex> update_watch_later(watch_later, %{field: new_value})
+      {:ok, %WatchLater{}}
+
+      iex> update_watch_later(watch_later, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_watch_later(%WatchLater{} = watch_later, attrs) do
+    watch_later
+    |> WatchLater.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a watch_later.
+
+  ## Examples
+
+      iex> delete_watch_later(watch_later)
+      {:ok, %WatchLater{}}
+
+      iex> delete_watch_later(watch_later)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_watch_later(%WatchLater{} = watch_later) do
+    Repo.delete(watch_later)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking watch_later changes.
+
+  ## Examples
+
+      iex> change_watch_later(watch_later)
+      %Ecto.Changeset{data: %WatchLater{}}
+
+  """
+  def change_watch_later(%WatchLater{} = watch_later, attrs \\ %{}) do
+    WatchLater.changeset(watch_later, attrs)
+  end
 end

--- a/lib/smovie/movies/watch_later.ex
+++ b/lib/smovie/movies/watch_later.ex
@@ -1,0 +1,21 @@
+defmodule Smovie.Movies.WatchLater do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "watchelater" do
+    field :id_movie, :integer
+    field :movie_description, :string
+    field :movie_title, :string
+
+    belongs_to :user, Smovie.Accounts.User
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(watch_later, attrs) do
+    watch_later
+    |> cast(attrs, [:id_movie, :movie_description, :movie_title])
+    |> validate_required([:id_movie, :movie_description, :movie_title])
+  end
+end

--- a/lib/smovie/tmdb.ex
+++ b/lib/smovie/tmdb.ex
@@ -1,5 +1,7 @@
 defmodule Smovie.TMDB do
-  @api_key System.get_env("API_TMDB")
+  # ici big effet de bord a voir
+  # @api_key System.get_env("API_TMDB")
+  @api_key "3b27f2809e11b60591c81a8eb4014c35"
   @base_url "https://api.themoviedb.org/3"
 
   # make a search by query and return a list of film

--- a/lib/smovie_web/live/home_live.ex
+++ b/lib/smovie_web/live/home_live.ex
@@ -1,17 +1,28 @@
 defmodule SmovieWeb.HomeLive do
-  use Phoenix.LiveView
+  use SmovieWeb, :live_view
+
   alias Smovie.TMDB
   alias Smovie.Repo
   alias Smovie.Movies.WatchedList
+  alias Smovie.Movies.WatchLater
 
   def mount(_params, _session, socket) do
     current_user = Map.get(socket.assigns, :current_user, nil)
 
     if connected?(socket), do: send(self(), :load_latest_movies)
 
-    {:ok, assign(socket, latest_movies: [], current_user: current_user, show_modal: false)}
+    {:ok,
+     assign(socket,
+       latest_movies: [],
+       current_user: current_user,
+       show_modal: false,
+       modal_type: nil,
+       selected_movie: nil,
+       modal_message: nil
+     )}
   end
 
+  # Load the latest movies from the TMDB API
   def handle_info(:load_latest_movies, socket) do
     case TMDB.get_latest_movies() do
       {:ok, %{"results" => results}} ->
@@ -22,17 +33,21 @@ defmodule SmovieWeb.HomeLive do
     end
   end
 
-  def handle_event("open_modal", %{"movie_id" => movie_id}, socket) do
+  # Open modal with the selected movie and modal type
+  def handle_event("open_modal", %{"movie_id" => movie_id, "modal_type" => modal_type}, socket) do
     selected_movie =
       Enum.find(socket.assigns.latest_movies, fn m -> m["id"] == String.to_integer(movie_id) end)
 
-    {:noreply, assign(socket, selected_movie: selected_movie, show_modal: true)}
+    {:noreply,
+     assign(socket, selected_movie: selected_movie, show_modal: true, modal_type: modal_type)}
   end
 
-  def handle_event("close_modal", _params, socket) do
-    {:noreply, assign(socket, show_modal: false, selected_movie: nil)}
+  # Close modal
+  def handle_event("close_modal", _, socket) do
+    {:noreply, assign(socket, show_modal: false, selected_movie: nil, modal_type: nil)}
   end
 
+  # Add the movie to the watched list
   def handle_event(
         "save_to_watchlist",
         %{"urating" => urating, "udescription" => udescription, "uwatcheddate" => uwatcheddate},
@@ -54,16 +69,63 @@ defmodule SmovieWeb.HomeLive do
 
     case Repo.insert(watched_list) do
       {:ok, _record} ->
-        {:noreply, assign(socket, show_modal: false, selected_movie: nil)}
+        {:noreply, assign(socket, show_modal: false, selected_movie: nil, modal_type: nil)}
 
       {:error, changeset} ->
         IO.inspect(changeset, label: "Failed to Insert Watched List")
 
         {:noreply,
-         assign(socket, show_modal: true, selected_movie: socket.assigns.selected_movie)}
+         assign(socket,
+           show_modal: true,
+           selected_movie: socket.assigns.selected_movie,
+           modal_type: "watchlist"
+         )}
     end
   end
 
+  # Add the movie to the watch later list
+  def handle_event("add_to_watch_later", %{"movie_id" => movie_id}, socket) do
+    movie =
+      Enum.find(socket.assigns.latest_movies, fn m -> m["id"] == String.to_integer(movie_id) end)
+
+    if movie do
+      watch_later = %WatchLater{
+        id_movie: movie["id"],
+        movie_title: movie["title"],
+        movie_description: movie["overview"],
+        user_id: socket.assigns.current_user.id
+      }
+
+      case Repo.insert(watch_later) do
+        {:ok, _record} ->
+          {:noreply,
+           assign(socket,
+             show_modal: true,
+             modal_message: "Film ajouté avec succès",
+             modal_type: "watch_later"
+           )}
+
+        {:error, changeset} ->
+          IO.inspect(changeset, label: "Failed to Insert Watch Later")
+
+          {:noreply,
+           assign(socket,
+             show_modal: true,
+             modal_message: "Erreur lors de l'ajout du film",
+             modal_type: "watch_later"
+           )}
+      end
+    else
+      {:noreply,
+       assign(socket,
+         show_modal: true,
+         modal_message: "Film non trouvé",
+         modal_type: "watch_later"
+       )}
+    end
+  end
+
+  # Render function using HEEx
   def render(assigns) do
     ~H"""
     <div>
@@ -76,8 +138,15 @@ defmodule SmovieWeb.HomeLive do
             <p>Date de sortie : {movie["release_date"]}</p>
             <p>Note : {movie["vote_average"]}</p>
             <%= if @current_user do %>
-              <button phx-click="open_modal" phx-value-movie_id={movie["id"]}>
+              <button
+                phx-click="open_modal"
+                phx-value-movie_id={movie["id"]}
+                phx-value-modal_type="watchlist"
+              >
                 Ajouter à la watchlist
+              </button>
+              <button phx-click="add_to_watch_later" phx-value-movie_id={movie["id"]}>
+                Ajouter à regarder plus tard
               </button>
             <% end %>
           </li>
@@ -87,27 +156,45 @@ defmodule SmovieWeb.HomeLive do
       <%= if @show_modal do %>
         <div id="modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
           <div class="bg-white p-6 rounded-lg shadow-lg w-1/3">
-            <h2 class="text-lg font-bold">Ajouter {@selected_movie["title"]} à votre watchlist</h2>
-            <form phx-submit="save_to_watchlist">
-              <label>Note :</label>
-              <input type="number" step="0.1" name="urating" required />
-              <label>Description :</label>
-              <textarea name="udescription"></textarea>
-              <label>Date de visionnage :</label>
-              <input type="date" name="uwatcheddate" required />
-              <div class="flex justify-end space-x-2 mt-4">
-                <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">
-                  Enregistrer
-                </button>
-                <button
-                  type="button"
-                  phx-click="close_modal"
-                  class="bg-gray-500 text-white px-4 py-2 rounded"
-                >
-                  Annuler
-                </button>
-              </div>
-            </form>
+            <%= if @modal_type == "watchlist" do %>
+              <h2 class="text-lg font-bold">Ajouter {@selected_movie["title"]} à votre watchlist</h2>
+              <form phx-submit="save_to_watchlist">
+                <label>Note :</label>
+                <input type="number" step="0.1" name="urating" required />
+                <label>Description :</label>
+                <textarea name="udescription"></textarea>
+                <label>Date de visionnage :</label>
+                <input type="date" name="uwatcheddate" required />
+                <div class="flex justify-end space-x-2 mt-4">
+                  <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">
+                    Enregistrer
+                  </button>
+                  <button
+                    type="button"
+                    phx-click="close_modal"
+                    class="bg-gray-500 text-white px-4 py-2 rounded"
+                  >
+                    Annuler
+                  </button>
+                </div>
+              </form>
+            <% else %>
+              <%= if @modal_type == "watch_later" do %>
+                <h2 class="text-lg font-bold">
+                  Ajouter {@selected_movie["title"]} à regarder plus tard
+                </h2>
+                <p>{@modal_message}</p>
+                <div class="flex justify-end space-x-2 mt-4">
+                  <button
+                    type="button"
+                    phx-click="close_modal"
+                    class="bg-gray-500 text-white px-4 py-2 rounded"
+                  >
+                    Fermer
+                  </button>
+                </div>
+              <% end %>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/lib/smovie_web/live/movie_search_live.ex
+++ b/lib/smovie_web/live/movie_search_live.ex
@@ -66,19 +66,34 @@ defmodule SmovieWeb.MovieSearchLive do
       id_movie: socket.assigns.selected_movie["id"]
     }
 
-    case Repo.insert(watched_list) do
-      {:ok, _record} ->
-        {:noreply, assign(socket, show_modal: false, selected_movie: nil, modal_type: nil)}
+    existing_entry =
+      Repo.get_by(WatchedList,
+        user_id: socket.assigns.current_user.id,
+        id_movie: socket.assigns.selected_movie["id"]
+      )
 
-      {:error, changeset} ->
-        IO.inspect(changeset, label: "Failed to Insert Watched List")
+    if existing_entry do
+      {:noreply,
+       assign(socket,
+         show_modal: true,
+         modal_message: "Film déjà dans la watchlist",
+         modal_type: "watchlist"
+       )}
+    else
+      case Repo.insert(watched_list) do
+        {:ok, _record} ->
+          {:noreply, assign(socket, show_modal: false, selected_movie: nil, modal_type: nil)}
 
-        {:noreply,
-         assign(socket,
-           show_modal: true,
-           selected_movie: socket.assigns.selected_movie,
-           modal_type: "watchlist"
-         )}
+        {:error, changeset} ->
+          IO.inspect(changeset, label: "Failed to Insert Watched List")
+
+          {:noreply,
+           assign(socket,
+             show_modal: true,
+             selected_movie: socket.assigns.selected_movie,
+             modal_type: "watchlist"
+           )}
+      end
     end
   end
 
@@ -87,31 +102,43 @@ defmodule SmovieWeb.MovieSearchLive do
       Enum.find(socket.assigns.results, fn m -> m["id"] == String.to_integer(movie_id) end)
 
     if movie do
-      watch_later = %WatchLater{
-        id_movie: movie["id"],
-        movie_title: movie["title"],
-        movie_description: movie["overview"],
-        user_id: socket.assigns.current_user.id
-      }
+      existing_entry =
+        Repo.get_by(WatchLater, user_id: socket.assigns.current_user.id, id_movie: movie["id"])
 
-      case Repo.insert(watch_later) do
-        {:ok, _record} ->
-          {:noreply,
-           assign(socket,
-             show_modal: true,
-             modal_message: "Film ajouté avec succès",
-             modal_type: "watch_later"
-           )}
+      if existing_entry do
+        {:noreply,
+         assign(socket,
+           show_modal: true,
+           modal_message: "Film déjà dans la liste à regarder plus tard",
+           modal_type: "watch_later"
+         )}
+      else
+        watch_later = %WatchLater{
+          id_movie: movie["id"],
+          movie_title: movie["title"],
+          movie_description: movie["overview"],
+          user_id: socket.assigns.current_user.id
+        }
 
-        {:error, changeset} ->
-          IO.inspect(changeset, label: "Failed to Insert Watch Later")
+        case Repo.insert(watch_later) do
+          {:ok, _record} ->
+            {:noreply,
+             assign(socket,
+               show_modal: true,
+               modal_message: "Film ajouté avec succès",
+               modal_type: "watch_later"
+             )}
 
-          {:noreply,
-           assign(socket,
-             show_modal: true,
-             modal_message: "Erreur lors de l'ajout du film",
-             modal_type: "watch_later"
-           )}
+          {:error, changeset} ->
+            IO.inspect(changeset, label: "Failed to Insert Watch Later")
+
+            {:noreply,
+             assign(socket,
+               show_modal: true,
+               modal_message: "Erreur lors de l'ajout du film",
+               modal_type: "watch_later"
+             )}
+        end
       end
     else
       {:noreply,

--- a/lib/smovie_web/live/movie_search_live.ex
+++ b/lib/smovie_web/live/movie_search_live.ex
@@ -4,6 +4,7 @@ defmodule SmovieWeb.MovieSearchLive do
   alias Smovie.Repo
   alias Smovie.Movies.WatchedList
   alias Phoenix.HTML
+  alias Smovie.Movies.WatchLater
 
   def mount(_params, _session, socket) do
     current_user = socket.assigns.current_user
@@ -38,15 +39,12 @@ defmodule SmovieWeb.MovieSearchLive do
     end
   end
 
-  def handle_event("open_modal", %{"movie_id" => movie_id}, socket) do
+  def handle_event("open_modal", %{"movie_id" => movie_id, "modal_type" => modal_type}, socket) do
     selected_movie =
       Enum.find(socket.assigns.results, fn m -> m["id"] == String.to_integer(movie_id) end)
 
-    {:noreply, assign(socket, selected_movie: selected_movie, show_modal: true)}
-  end
-
-  def handle_event("close_modal", _params, socket) do
-    {:noreply, assign(socket, show_modal: false, selected_movie: nil)}
+    {:noreply,
+     assign(socket, selected_movie: selected_movie, show_modal: true, modal_type: modal_type)}
   end
 
   def handle_event(
@@ -70,14 +68,63 @@ defmodule SmovieWeb.MovieSearchLive do
 
     case Repo.insert(watched_list) do
       {:ok, _record} ->
-        {:noreply, assign(socket, show_modal: false, selected_movie: nil)}
+        {:noreply, assign(socket, show_modal: false, selected_movie: nil, modal_type: nil)}
 
       {:error, changeset} ->
         IO.inspect(changeset, label: "Failed to Insert Watched List")
 
         {:noreply,
-         assign(socket, show_modal: true, selected_movie: socket.assigns.selected_movie)}
+         assign(socket,
+           show_modal: true,
+           selected_movie: socket.assigns.selected_movie,
+           modal_type: "watchlist"
+         )}
     end
+  end
+
+  def handle_event("add_to_watch_later", %{"movie_id" => movie_id}, socket) do
+    movie =
+      Enum.find(socket.assigns.results, fn m -> m["id"] == String.to_integer(movie_id) end)
+
+    if movie do
+      watch_later = %WatchLater{
+        id_movie: movie["id"],
+        movie_title: movie["title"],
+        movie_description: movie["overview"],
+        user_id: socket.assigns.current_user.id
+      }
+
+      case Repo.insert(watch_later) do
+        {:ok, _record} ->
+          {:noreply,
+           assign(socket,
+             show_modal: true,
+             modal_message: "Film ajouté avec succès",
+             modal_type: "watch_later"
+           )}
+
+        {:error, changeset} ->
+          IO.inspect(changeset, label: "Failed to Insert Watch Later")
+
+          {:noreply,
+           assign(socket,
+             show_modal: true,
+             modal_message: "Erreur lors de l'ajout du film",
+             modal_type: "watch_later"
+           )}
+      end
+    else
+      {:noreply,
+       assign(socket,
+         show_modal: true,
+         modal_message: "Film non trouvé",
+         modal_type: "watch_later"
+       )}
+    end
+  end
+
+  def handle_event("close_modal", _, socket) do
+    {:noreply, assign(socket, show_modal: false, selected_movie: nil, modal_type: nil)}
   end
 
   def render(assigns) do
@@ -93,8 +140,15 @@ defmodule SmovieWeb.MovieSearchLive do
             <img src={"https://image.tmdb.org/t/p/w500#{movie["poster_path"]}"} alt={movie["title"]} />
             {movie["title"]} ({movie["release_date"]})
             <p>{movie["vote_average"]}</p>
-            <button phx-click="open_modal" phx-value-movie_id={movie["id"]}>
+            <button
+              phx-click="open_modal"
+              phx-value-movie_id={movie["id"]}
+              phx-value-modal_type="watchlist"
+            >
               Ajouter à la watchlist
+            </button>
+            <button phx-click="add_to_watch_later" phx-value-movie_id={movie["id"]}>
+              Ajouter à regarder plus tard
             </button>
           </li>
         <% end %>
@@ -103,27 +157,45 @@ defmodule SmovieWeb.MovieSearchLive do
       <%= if @show_modal do %>
         <div id="modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
           <div class="bg-white p-6 rounded-lg shadow-lg w-1/3">
-            <h2 class="text-lg font-bold">Ajouter {@selected_movie["title"]} à votre watchlist</h2>
-            <form phx-submit="save_to_watchlist">
-              <label>Note :</label>
-              <input type="number" step="0.1" name="urating" required />
-              <label>Description :</label>
-              <textarea name="udescription"></textarea>
-              <label>Date de visionnage :</label>
-              <input type="date" name="uwatcheddate" required />
-              <div class="flex justify-end space-x-2 mt-4">
-                <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">
-                  Enregistrer
-                </button>
-                <button
-                  type="button"
-                  phx-click="close_modal"
-                  class="bg-gray-500 text-white px-4 py-2 rounded"
-                >
-                  Annuler
-                </button>
-              </div>
-            </form>
+            <%= if @modal_type == "watchlist" do %>
+              <h2 class="text-lg font-bold">Ajouter {@selected_movie["title"]} à votre watchlist</h2>
+              <form phx-submit="save_to_watchlist">
+                <label>Note :</label>
+                <input type="number" step="0.1" name="urating" required />
+                <label>Description :</label>
+                <textarea name="udescription"></textarea>
+                <label>Date de visionnage :</label>
+                <input type="date" name="uwatcheddate" required />
+                <div class="flex justify-end space-x-2 mt-4">
+                  <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">
+                    Enregistrer
+                  </button>
+                  <button
+                    type="button"
+                    phx-click="close_modal"
+                    class="bg-gray-500 text-white px-4 py-2 rounded"
+                  >
+                    Annuler
+                  </button>
+                </div>
+              </form>
+            <% else %>
+              <%= if @modal_type == "watch_later" do %>
+                <h2 class="text-lg font-bold">
+                  Ajouter {@selected_movie["title"]} à regarder plus tard
+                </h2>
+                <p>{@modal_message}</p>
+                <div class="flex justify-end space-x-2 mt-4">
+                  <button
+                    type="button"
+                    phx-click="close_modal"
+                    class="bg-gray-500 text-white px-4 py-2 rounded"
+                  >
+                    Fermer
+                  </button>
+                </div>
+              <% end %>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/lib/smovie_web/live/watch_later_live/form_component.ex
+++ b/lib/smovie_web/live/watch_later_live/form_component.ex
@@ -1,0 +1,84 @@
+defmodule SmovieWeb.WatchLaterLive.FormComponent do
+  use SmovieWeb, :live_component
+
+  alias Smovie.Movies
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.header>
+        {@title}
+        <:subtitle>Use this form to manage watch_later records in your database.</:subtitle>
+      </.header>
+
+      <.simple_form
+        for={@form}
+        id="watch_later-form"
+        phx-target={@myself}
+        phx-change="validate"
+        phx-submit="save"
+      >
+        <.input field={@form[:id_movie]} type="number" label="Id movie" />
+        <.input field={@form[:movie_description]} type="text" label="Movie description" />
+        <.input field={@form[:movie_title]} type="text" label="Movie title" />
+        <:actions>
+          <.button phx-disable-with="Saving...">Save Watch later</.button>
+        </:actions>
+      </.simple_form>
+    </div>
+    """
+  end
+
+  @impl true
+  def update(%{watch_later: watch_later} = assigns, socket) do
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign_new(:form, fn ->
+       to_form(Movies.change_watch_later(watch_later))
+     end)}
+  end
+
+  @impl true
+  def handle_event("validate", %{"watch_later" => watch_later_params}, socket) do
+    changeset = Movies.change_watch_later(socket.assigns.watch_later, watch_later_params)
+    {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
+  end
+
+  def handle_event("save", %{"watch_later" => watch_later_params}, socket) do
+    save_watch_later(socket, socket.assigns.action, watch_later_params)
+  end
+
+  defp save_watch_later(socket, :edit, watch_later_params) do
+    case Movies.update_watch_later(socket.assigns.watch_later, watch_later_params) do
+      {:ok, watch_later} ->
+        notify_parent({:saved, watch_later})
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Watch later updated successfully")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+  defp save_watch_later(socket, :new, watch_later_params) do
+    case Movies.create_watch_later(watch_later_params) do
+      {:ok, watch_later} ->
+        notify_parent({:saved, watch_later})
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Watch later created successfully")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+  defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
+end

--- a/lib/smovie_web/live/watch_later_live/index.ex
+++ b/lib/smovie_web/live/watch_later_live/index.ex
@@ -1,0 +1,47 @@
+defmodule SmovieWeb.WatchLaterLive.Index do
+  use SmovieWeb, :live_view
+
+  alias Smovie.Movies
+  alias Smovie.Movies.WatchLater
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, stream(socket, :watchelater, Movies.list_watchelater())}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}) do
+    socket
+    |> assign(:page_title, "Edit Watch later")
+    |> assign(:watch_later, Movies.get_watch_later!(id))
+  end
+
+  defp apply_action(socket, :new, _params) do
+    socket
+    |> assign(:page_title, "New Watch later")
+    |> assign(:watch_later, %WatchLater{})
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, "Listing Watchelater")
+    |> assign(:watch_later, nil)
+  end
+
+  @impl true
+  def handle_info({SmovieWeb.WatchLaterLive.FormComponent, {:saved, watch_later}}, socket) do
+    {:noreply, stream_insert(socket, :watchelater, watch_later)}
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    watch_later = Movies.get_watch_later!(id)
+    {:ok, _} = Movies.delete_watch_later(watch_later)
+
+    {:noreply, stream_delete(socket, :watchelater, watch_later)}
+  end
+end

--- a/lib/smovie_web/live/watch_later_live/index.html.heex
+++ b/lib/smovie_web/live/watch_later_live/index.html.heex
@@ -1,0 +1,43 @@
+<.header>
+  Listing Watchelater
+  <:actions>
+    <.link patch={~p"/watchelater/new"}>
+      <.button>New Watch later</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.table
+  id="watchelater"
+  rows={@streams.watchelater}
+  row_click={fn {_id, watch_later} -> JS.navigate(~p"/watchelater/#{watch_later}") end}
+>
+  <:col :let={{_id, watch_later}} label="Id movie">{watch_later.id_movie}</:col>
+  <:col :let={{_id, watch_later}} label="Movie description">{watch_later.movie_description}</:col>
+  <:col :let={{_id, watch_later}} label="Movie title">{watch_later.movie_title}</:col>
+  <:action :let={{_id, watch_later}}>
+    <div class="sr-only">
+      <.link navigate={~p"/watchelater/#{watch_later}"}>Show</.link>
+    </div>
+    <.link patch={~p"/watchelater/#{watch_later}/edit"}>Edit</.link>
+  </:action>
+  <:action :let={{id, watch_later}}>
+    <.link
+      phx-click={JS.push("delete", value: %{id: watch_later.id}) |> hide("##{id}")}
+      data-confirm="Are you sure?"
+    >
+      Delete
+    </.link>
+  </:action>
+</.table>
+
+<.modal :if={@live_action in [:new, :edit]} id="watch_later-modal" show on_cancel={JS.patch(~p"/watchelater")}>
+  <.live_component
+    module={SmovieWeb.WatchLaterLive.FormComponent}
+    id={@watch_later.id || :new}
+    title={@page_title}
+    action={@live_action}
+    watch_later={@watch_later}
+    patch={~p"/watchelater"}
+  />
+</.modal>

--- a/lib/smovie_web/live/watch_later_live/show.ex
+++ b/lib/smovie_web/live/watch_later_live/show.ex
@@ -1,0 +1,21 @@
+defmodule SmovieWeb.WatchLaterLive.Show do
+  use SmovieWeb, :live_view
+
+  alias Smovie.Movies
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(%{"id" => id}, _, socket) do
+    {:noreply,
+     socket
+     |> assign(:page_title, page_title(socket.assigns.live_action))
+     |> assign(:watch_later, Movies.get_watch_later!(id))}
+  end
+
+  defp page_title(:show), do: "Show Watch later"
+  defp page_title(:edit), do: "Edit Watch later"
+end

--- a/lib/smovie_web/live/watch_later_live/show.html.heex
+++ b/lib/smovie_web/live/watch_later_live/show.html.heex
@@ -1,0 +1,28 @@
+<.header>
+  Watch later {@watch_later.id}
+  <:subtitle>This is a watch_later record from your database.</:subtitle>
+  <:actions>
+    <.link patch={~p"/watchelater/#{@watch_later}/show/edit"} phx-click={JS.push_focus()}>
+      <.button>Edit watch_later</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.list>
+  <:item title="Id movie">{@watch_later.id_movie}</:item>
+  <:item title="Movie description">{@watch_later.movie_description}</:item>
+  <:item title="Movie title">{@watch_later.movie_title}</:item>
+</.list>
+
+<.back navigate={~p"/watchelater"}>Back to watchelater</.back>
+
+<.modal :if={@live_action == :edit} id="watch_later-modal" show on_cancel={JS.patch(~p"/watchelater/#{@watch_later}")}>
+  <.live_component
+    module={SmovieWeb.WatchLaterLive.FormComponent}
+    id={@watch_later.id}
+    title={@page_title}
+    action={@live_action}
+    watch_later={@watch_later}
+    patch={~p"/watchelater/#{@watch_later}"}
+  />
+</.modal>

--- a/lib/smovie_web/live/watch_later_live/watch_later_live.ex
+++ b/lib/smovie_web/live/watch_later_live/watch_later_live.ex
@@ -23,16 +23,39 @@ defmodule SmovieWeb.WatchLaterLive do
     end)
   end
 
+  def handle_event("delete", %{"id" => entry_id}, socket) do
+    current_user_id = socket.assigns.current_user.id
+
+    entry = Movies.get_watch_later!(entry_id)
+
+    if entry.user_id == current_user_id do
+      Movies.delete_watch_later(entry)
+
+      watch_later_list = Movies.list_watch_later_for_user(current_user_id)
+      movie_details = fetch_movie_details(watch_later_list)
+
+      {:noreply, assign(socket, watch_later_list: watch_later_list, movie_details: movie_details)}
+    else
+      {:noreply, put_flash(socket, :error, "Vous n'êtes pas autorisé à supprimer ce film.")}
+    end
+  end
+
   def render(assigns) do
     ~H"""
     <div>
       <h1>Ma Liste de Films à Regarder Plus Tard</h1>
+      <%= if @flash[:error] do %>
+        <div class="alert alert-danger">
+          {@flash[:error]}
+        </div>
+      <% end %>
       <table>
         <thead>
           <tr>
             <th>Image</th>
             <th>Titre</th>
             <th>Description</th>
+            <th>Action</th>
           </tr>
         </thead>
         <tbody>
@@ -53,6 +76,9 @@ defmodule SmovieWeb.WatchLaterLive do
                 <% end %>
               </td>
               <td>{entry.movie_description}</td>
+              <td>
+                <button phx-click="delete" phx-value-id={entry.id}>Supprimer</button>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/lib/smovie_web/live/watch_later_live/watch_later_live.ex
+++ b/lib/smovie_web/live/watch_later_live/watch_later_live.ex
@@ -1,0 +1,63 @@
+defmodule SmovieWeb.WatchLaterLive do
+  use Phoenix.LiveView
+  alias Smovie.Movies
+  alias Smovie.TMDB
+
+  def mount(_params, _session, %{assigns: %{current_user: current_user}} = socket) do
+    if connected?(socket), do: send(self(), :load_watch_later_list)
+    {:ok, assign(socket, current_user: current_user, watch_later_list: [], movie_details: %{})}
+  end
+
+  def handle_info(:load_watch_later_list, socket) do
+    watch_later_list = Movies.list_watch_later_for_user(socket.assigns.current_user.id)
+    movie_details = fetch_movie_details(watch_later_list)
+    {:noreply, assign(socket, watch_later_list: watch_later_list, movie_details: movie_details)}
+  end
+
+  defp fetch_movie_details(watch_later_list) do
+    Enum.reduce(watch_later_list, %{}, fn entry, acc ->
+      case TMDB.get_movie_details(entry.id_movie) do
+        {:ok, details} -> Map.put(acc, entry.id_movie, details)
+        {:error, _reason} -> acc
+      end
+    end)
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div>
+      <h1>Ma Liste de Films à Regarder Plus Tard</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Image</th>
+            <th>Titre</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= for entry <- @watch_later_list do %>
+            <tr>
+              <td>
+                <%= if details = @movie_details[entry.id_movie] do %>
+                  <img
+                    src={"https://image.tmdb.org/t/p/w500#{details["poster_path"]}"}
+                    alt={details["title"]}
+                    class="h-9 w-9"
+                  />
+                <% end %>
+              </td>
+              <td>
+                <%= if details = @movie_details[entry.id_movie] do %>
+                  {details["title"]}
+                <% end %>
+              </td>
+              <td>{entry.movie_description}</td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+end

--- a/lib/smovie_web/live/watched_list_live/watched_list_live.ex
+++ b/lib/smovie_web/live/watched_list_live/watched_list_live.ex
@@ -24,10 +24,32 @@ defmodule SmovieWeb.WatchedListLive do
     end)
   end
 
+  def handle_event("delete", %{"id" => entry_id}, socket) do
+    current_user_id = socket.assigns.current_user.id
+
+    entry = Movies.get_watched_list!(entry_id)
+
+    if entry.user_id == current_user_id do
+      Movies.delete_watched_list(entry)
+
+      watched_list = Movies.list_watched_lists_for_user(current_user_id)
+      movie_details = fetch_movie_details(watched_list)
+
+      {:noreply, assign(socket, watched_list: watched_list, movie_details: movie_details)}
+    else
+      {:noreply, put_flash(socket, :error, "Vous n'êtes pas autorisé à supprimer ce film.")}
+    end
+  end
+
   def render(assigns) do
     ~H"""
     <div>
       <h1>Ma Liste de Films Regardés</h1>
+      <%= if @flash[:error] do %>
+        <div class="alert alert-danger">
+          {@flash[:error]}
+        </div>
+      <% end %>
       <table>
         <thead>
           <tr>
@@ -36,6 +58,7 @@ defmodule SmovieWeb.WatchedListLive do
             <th>Note</th>
             <th>Description</th>
             <th>Date de Visionnage</th>
+            <th>Action</th>
           </tr>
         </thead>
         <tbody>
@@ -58,6 +81,7 @@ defmodule SmovieWeb.WatchedListLive do
               <td>{entry.urating}</td>
               <td>{entry.udescription}</td>
               <td>{entry.uwatcheddate}</td>
+              <td><button phx-click="delete" phx-value-id={entry.id}>Supprimer</button></td>
             </tr>
           <% end %>
         </tbody>

--- a/lib/smovie_web/router.ex
+++ b/lib/smovie_web/router.ex
@@ -75,6 +75,15 @@ defmodule SmovieWeb.Router do
       live "/watchedlist/:id/show/edit", WatchedListLive.Show, :edit
       live "/search", MovieSearchLive, :index
       live "/watched_list", WatchedListLive, :index
+
+      live "/watchelater", WatchLaterLive.Index, :index
+      live "/watchelater/new", WatchLaterLive.Index, :new
+      live "/watchelater/:id/edit", WatchLaterLive.Index, :edit
+
+      live "/watchelater/:id", WatchLaterLive.Show, :show
+      live "/watchelater/:id/show/edit", WatchLaterLive.Show, :edit
+
+      live "/watch_later", WatchLaterLive, :index
     end
   end
 

--- a/priv/repo/migrations/20250226144329_create_watchelater.exs
+++ b/priv/repo/migrations/20250226144329_create_watchelater.exs
@@ -1,0 +1,16 @@
+defmodule Smovie.Repo.Migrations.CreateWatchelater do
+  use Ecto.Migration
+
+  def change do
+    create table(:watchelater) do
+      add :id_movie, :integer
+      add :movie_description, :string
+      add :movie_title, :string
+      add :user, references(:users, on_delete: :nothing)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:watchelater, [:user])
+  end
+end

--- a/priv/repo/migrations/20250226144802_add_user_id_to_watchelater.exs
+++ b/priv/repo/migrations/20250226144802_add_user_id_to_watchelater.exs
@@ -1,0 +1,11 @@
+defmodule Smovie.Repo.Migrations.AddUserIdToWatchelater do
+  use Ecto.Migration
+
+  def change do
+    alter table(:watchelater) do
+      add :user_id, references(:users, on_delete: :nothing)
+    end
+
+    create index(:watchelater, [:user_id])
+  end
+end

--- a/priv/repo/migrations/20250302123558_increase_movie_description_length.exs
+++ b/priv/repo/migrations/20250302123558_increase_movie_description_length.exs
@@ -1,0 +1,9 @@
+defmodule Smovie.Repo.Migrations.IncreaseMovieDescriptionLength do
+  use Ecto.Migration
+
+  def change do
+    alter table(:watchelater) do
+      modify :movie_description, :string, size: 1000
+    end
+  end
+end

--- a/test/smovie/movies_test.exs
+++ b/test/smovie/movies_test.exs
@@ -60,4 +60,62 @@ defmodule Smovie.MoviesTest do
       assert %Ecto.Changeset{} = Movies.change_watched_list(watched_list)
     end
   end
+
+  describe "watchelater" do
+    alias Smovie.Movies.WatchLater
+
+    import Smovie.MoviesFixtures
+
+    @invalid_attrs %{id_movie: nil, movie_description: nil, movie_title: nil}
+
+    test "list_watchelater/0 returns all watchelater" do
+      watch_later = watch_later_fixture()
+      assert Movies.list_watchelater() == [watch_later]
+    end
+
+    test "get_watch_later!/1 returns the watch_later with given id" do
+      watch_later = watch_later_fixture()
+      assert Movies.get_watch_later!(watch_later.id) == watch_later
+    end
+
+    test "create_watch_later/1 with valid data creates a watch_later" do
+      valid_attrs = %{id_movie: 42, movie_description: "some movie_description", movie_title: "some movie_title"}
+
+      assert {:ok, %WatchLater{} = watch_later} = Movies.create_watch_later(valid_attrs)
+      assert watch_later.id_movie == 42
+      assert watch_later.movie_description == "some movie_description"
+      assert watch_later.movie_title == "some movie_title"
+    end
+
+    test "create_watch_later/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Movies.create_watch_later(@invalid_attrs)
+    end
+
+    test "update_watch_later/2 with valid data updates the watch_later" do
+      watch_later = watch_later_fixture()
+      update_attrs = %{id_movie: 43, movie_description: "some updated movie_description", movie_title: "some updated movie_title"}
+
+      assert {:ok, %WatchLater{} = watch_later} = Movies.update_watch_later(watch_later, update_attrs)
+      assert watch_later.id_movie == 43
+      assert watch_later.movie_description == "some updated movie_description"
+      assert watch_later.movie_title == "some updated movie_title"
+    end
+
+    test "update_watch_later/2 with invalid data returns error changeset" do
+      watch_later = watch_later_fixture()
+      assert {:error, %Ecto.Changeset{}} = Movies.update_watch_later(watch_later, @invalid_attrs)
+      assert watch_later == Movies.get_watch_later!(watch_later.id)
+    end
+
+    test "delete_watch_later/1 deletes the watch_later" do
+      watch_later = watch_later_fixture()
+      assert {:ok, %WatchLater{}} = Movies.delete_watch_later(watch_later)
+      assert_raise Ecto.NoResultsError, fn -> Movies.get_watch_later!(watch_later.id) end
+    end
+
+    test "change_watch_later/1 returns a watch_later changeset" do
+      watch_later = watch_later_fixture()
+      assert %Ecto.Changeset{} = Movies.change_watch_later(watch_later)
+    end
+  end
 end

--- a/test/smovie_web/live/watch_later_live_test.exs
+++ b/test/smovie_web/live/watch_later_live_test.exs
@@ -1,0 +1,113 @@
+defmodule SmovieWeb.WatchLaterLiveTest do
+  use SmovieWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Smovie.MoviesFixtures
+
+  @create_attrs %{id_movie: 42, movie_description: "some movie_description", movie_title: "some movie_title"}
+  @update_attrs %{id_movie: 43, movie_description: "some updated movie_description", movie_title: "some updated movie_title"}
+  @invalid_attrs %{id_movie: nil, movie_description: nil, movie_title: nil}
+
+  defp create_watch_later(_) do
+    watch_later = watch_later_fixture()
+    %{watch_later: watch_later}
+  end
+
+  describe "Index" do
+    setup [:create_watch_later]
+
+    test "lists all watchelater", %{conn: conn, watch_later: watch_later} do
+      {:ok, _index_live, html} = live(conn, ~p"/watchelater")
+
+      assert html =~ "Listing Watchelater"
+      assert html =~ watch_later.movie_description
+    end
+
+    test "saves new watch_later", %{conn: conn} do
+      {:ok, index_live, _html} = live(conn, ~p"/watchelater")
+
+      assert index_live |> element("a", "New Watch later") |> render_click() =~
+               "New Watch later"
+
+      assert_patch(index_live, ~p"/watchelater/new")
+
+      assert index_live
+             |> form("#watch_later-form", watch_later: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert index_live
+             |> form("#watch_later-form", watch_later: @create_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/watchelater")
+
+      html = render(index_live)
+      assert html =~ "Watch later created successfully"
+      assert html =~ "some movie_description"
+    end
+
+    test "updates watch_later in listing", %{conn: conn, watch_later: watch_later} do
+      {:ok, index_live, _html} = live(conn, ~p"/watchelater")
+
+      assert index_live |> element("#watchelater-#{watch_later.id} a", "Edit") |> render_click() =~
+               "Edit Watch later"
+
+      assert_patch(index_live, ~p"/watchelater/#{watch_later}/edit")
+
+      assert index_live
+             |> form("#watch_later-form", watch_later: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert index_live
+             |> form("#watch_later-form", watch_later: @update_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/watchelater")
+
+      html = render(index_live)
+      assert html =~ "Watch later updated successfully"
+      assert html =~ "some updated movie_description"
+    end
+
+    test "deletes watch_later in listing", %{conn: conn, watch_later: watch_later} do
+      {:ok, index_live, _html} = live(conn, ~p"/watchelater")
+
+      assert index_live |> element("#watchelater-#{watch_later.id} a", "Delete") |> render_click()
+      refute has_element?(index_live, "#watchelater-#{watch_later.id}")
+    end
+  end
+
+  describe "Show" do
+    setup [:create_watch_later]
+
+    test "displays watch_later", %{conn: conn, watch_later: watch_later} do
+      {:ok, _show_live, html} = live(conn, ~p"/watchelater/#{watch_later}")
+
+      assert html =~ "Show Watch later"
+      assert html =~ watch_later.movie_description
+    end
+
+    test "updates watch_later within modal", %{conn: conn, watch_later: watch_later} do
+      {:ok, show_live, _html} = live(conn, ~p"/watchelater/#{watch_later}")
+
+      assert show_live |> element("a", "Edit") |> render_click() =~
+               "Edit Watch later"
+
+      assert_patch(show_live, ~p"/watchelater/#{watch_later}/show/edit")
+
+      assert show_live
+             |> form("#watch_later-form", watch_later: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert show_live
+             |> form("#watch_later-form", watch_later: @update_attrs)
+             |> render_submit()
+
+      assert_patch(show_live, ~p"/watchelater/#{watch_later}")
+
+      html = render(show_live)
+      assert html =~ "Watch later updated successfully"
+      assert html =~ "some updated movie_description"
+    end
+  end
+end

--- a/test/support/fixtures/movies_fixtures.ex
+++ b/test/support/fixtures/movies_fixtures.ex
@@ -19,4 +19,20 @@ defmodule Smovie.MoviesFixtures do
 
     watched_list
   end
+
+  @doc """
+  Generate a watch_later.
+  """
+  def watch_later_fixture(attrs \\ %{}) do
+    {:ok, watch_later} =
+      attrs
+      |> Enum.into(%{
+        id_movie: 42,
+        movie_description: "some movie_description",
+        movie_title: "some movie_title"
+      })
+      |> Smovie.Movies.create_watch_later()
+
+    watch_later
+  end
 end


### PR DESCRIPTION
This pull request introduces a new feature for managing a "watch later" list in the Smovie application. The changes include adding new database schema, functions, and updates to the user interface to support this feature.

### Database and Schema Changes:
* Added a new schema `Smovie.Movies.WatchLater` to represent the "watch later" list in the database. (`lib/smovie/movies/watch_later.ex`)
* Updated the `Smovie.Accounts.User` schema to include a relationship with the "watch later" list. (`lib/smovie/accounts/user.ex`)

### Backend Functionality:
* Introduced various functions in `Smovie.Movies` module to handle CRUD operations for the "watch later" list, such as `list_watchelater`, `get_watch_later!`, `create_watch_later`, `update_watch_later`, and `delete_watch_later`. (`lib/smovie/movies.ex`)

### User Interface Enhancements:
* Updated the `HomeLive` and `MovieSearchLive` modules to handle adding movies to the "watch later" list, including opening modals and displaying success/error messages. (`lib/smovie_web/live/home_live.ex`) [[1]](diffhunk://#diff-6746dff41d9eee518bbe0cedc7c5e8fb23211079cd750b40a4e40f82596e5f20L2-R25) [[2]](diffhunk://#diff-6746dff41d9eee518bbe0cedc7c5e8fb23211079cd750b40a4e40f82596e5f20L25-R50) [[3]](diffhunk://#diff-6746dff41d9eee518bbe0cedc7c5e8fb23211079cd750b40a4e40f82596e5f20L57-R128) [[4]](diffhunk://#diff-6746dff41d9eee518bbe0cedc7c5e8fb23211079cd750b40a4e40f82596e5f20L79-R150) [[5]](diffhunk://#diff-6746dff41d9eee518bbe0cedc7c5e8fb23211079cd750b40a4e40f82596e5f20R159) [[6]](diffhunk://#diff-6746dff41d9eee518bbe0cedc7c5e8fb23211079cd750b40a4e40f82596e5f20R181-R197)
* Added new live view components for managing the "watch later" list, including forms and an index page. (`lib/smovie_web/live/watch_later_live/form_component.ex`, `lib/smovie_web/live/watch_later_live/index.ex`) [[1]](diffhunk://#diff-167746f68c1cf89f3cd377c1b728c6288c986406947820c5d8cd7bca6d9c37beR1-R84) [[2]](diffhunk://#diff-309236bc430ccedb121b00c4feb0ed73c708262ad98fa013aa561d81d66cc6c2R1-R47)

### API Key Change:
* Temporarily replaced the TMDB API key with a hardcoded value for testing purposes. (`lib/smovie/tmdb.ex`)

These changes collectively enhance the Smovie application by allowing users to manage a list of movies they intend to watch later, improving the overall user experience.